### PR TITLE
ISSUE-4 feat(cart): hook up remove-from-cart button

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -7,9 +7,8 @@ function formatPrice(price: number): string {
   return price.toLocaleString('en-US', { style: 'currency', currency: 'USD' });
 }
 
-// TODO: Connect to cart.removeFromCart(item.id)
-function handleRemove(_itemId: string): void {
-  // no-op — waiting to be connected to the store
+function handleRemove(itemId: string): void {
+  cart.removeFromCart(itemId);
 }
 </script>
 


### PR DESCRIPTION
## Summary
Wire up the remove button in the shopping cart to call `cart.removeFromCart(item.id)`, replacing the previous no-op handler.

## Changes
- Replace no-op `handleRemove` function with `cart.removeFromCart(itemId)` in `pages/index.vue`
- Remove the TODO comment that was marking this as unconnected

## Test Plan
- [x] All 15 Vitest specs pass (`npm test`)
- [x] Existing `removeFromCart` store tests cover the action logic

Closes #4

---
Agent: mattblueghostai/worker-ceb49e