### PR TITLE
ISSUE-3 feat(cart): enable quantity stepper on cart items

### DIFF
--- a/.cate/workflows.json
+++ b/.cate/workflows.json
@@ -1,24 +1,36 @@
 {
   "version": "2",
-  "demo": true,
   "project": {
     "name": "cate-demo-matt-11",
     "description": "Demo shopping cart project — powered by Cate"
   },
   "tracker": {
     "provider": "github",
-    "projectName": "cate-demo-matt-11",
-    "statusOptions": {
-      "ready": { "optionId": "fe3aa7e9" },
-      "in_progress": { "optionId": "a88ba220" },
-      "in_review": { "optionId": "c76db955" },
-      "human_review": { "optionId": "8bd66351" },
-      "done": { "optionId": "a8a101c1" }
+    "owner": {
+      "name": "matt-blueghost",
+      "type": "OWNER_TYPE_USER"
     },
-    "owner": { "name": "matt-blueghost", "type": "OWNER_TYPE_USER" },
     "repo": "cate-demo-matt-11",
+    "projectName": "cate-demo-matt-11",
     "projectNumber": 12,
-    "statusFieldId": "PVTSSF_lAHOD8maUs4BSqJ1zhAIMEY"
+    "statusFieldId": "PVTSSF_lAHOD8maUs4BSqJ1zhAIMEY",
+    "statusOptions": {
+      "ready": {
+        "optionId": "fe3aa7e9"
+      },
+      "in_progress": {
+        "optionId": "a88ba220"
+      },
+      "in_review": {
+        "optionId": "c76db955"
+      },
+      "human_review": {
+        "optionId": "8bd66351"
+      },
+      "done": {
+        "optionId": "a8a101c1"
+      }
+    }
   },
   "git": {
     "defaultBranch": "main",
@@ -29,32 +41,42 @@
     "default": "full"
   },
   "statuses": [
-    { "id": "ready", "name": "To Do", "color": "#3b82f6" },
-    { "id": "in_progress", "name": "In Progress", "color": "#f59e0b" },
-    { "id": "in_review", "name": "AI Review", "color": "#8b5cf6" },
-    { "id": "human_review", "name": "In Review", "color": "#ec4899" },
-    { "id": "done", "name": "Done", "color": "#22c55e" }
-  ],
-  "queue": {
-    "worker": {
-      "entries": [{ "status": "ready" }]
+    {
+      "id": "ready",
+      "name": "To Do",
+      "color": "#3b82f6"
     },
-    "reviewer": {
-      "entries": [{ "status": "in_review" }]
+    {
+      "id": "in_progress",
+      "name": "In Progress",
+      "color": "#f59e0b"
     },
-    "human-review": {
-      "entries": [{ "status": "human_review" }]
+    {
+      "id": "in_review",
+      "name": "AI Review",
+      "color": "#8b5cf6"
     },
-    "in_progress": {
-      "entries": [{ "status": "in_progress" }]
+    {
+      "id": "human_review",
+      "name": "In Review",
+      "color": "#ec4899"
+    },
+    {
+      "id": "done",
+      "name": "Done",
+      "color": "#22c55e"
     }
-  },
+  ],
   "commands": {
     "work": {
       "name": "Work",
       "description": "Find and execute the highest-priority task",
       "prompt": "commands/work.md",
-      "tab": { "persistent": { "minAllocation": 3 } },
+      "tab": {
+        "persistent": {
+          "minAllocation": 3
+        }
+      },
       "parameters": {
         "issue_id": {
           "type": "string",
@@ -63,17 +85,37 @@
         }
       },
       "transitions": [
-        { "on": "claim_new", "from": "ready", "to": "in_progress" },
-        { "on": "submit", "from": "in_progress", "to": "in_review" },
-        { "on": "promote_parent", "from": "ready", "to": "in_progress" },
-        { "on": "stuck", "from": "in_progress", "to": "ready" }
+        {
+          "from": "ready",
+          "to": "in_progress",
+          "on": "claim_new"
+        },
+        {
+          "from": "in_progress",
+          "to": "in_review",
+          "on": "submit"
+        },
+        {
+          "from": "ready",
+          "to": "in_progress",
+          "on": "promote_parent"
+        },
+        {
+          "from": "in_progress",
+          "to": "ready",
+          "on": "stuck"
+        }
       ]
     },
     "review": {
       "name": "Review",
       "description": "Review a pull request for correctness and quality",
       "prompt": "commands/review.md",
-      "tab": { "persistent": { "minAllocation": 1 } },
+      "tab": {
+        "persistent": {
+          "minAllocation": 1
+        }
+      },
       "parameters": {
         "issue_id": {
           "type": "string",
@@ -82,12 +124,79 @@
         }
       },
       "transitions": [
-        { "on": "approve", "from": "in_review", "to": "human_review" },
-        { "on": "approve_subtask", "from": "in_review", "to": "done" },
-        { "on": "approve_supervised", "from": "in_review", "to": "human_review" },
-        { "on": "request_changes", "from": "in_review", "to": "ready" },
-        { "on": "complete_epic", "from": "in_progress", "to": "human_review" }
+        {
+          "from": "in_review",
+          "to": "human_review",
+          "on": "approve"
+        },
+        {
+          "from": "in_review",
+          "to": "done",
+          "on": "approve_subtask"
+        },
+        {
+          "from": "in_review",
+          "to": "human_review",
+          "on": "approve_supervised"
+        },
+        {
+          "from": "in_review",
+          "to": "ready",
+          "on": "request_changes"
+        },
+        {
+          "from": "in_progress",
+          "to": "human_review",
+          "on": "complete_epic"
+        }
+      ]
+    },
+    "run_config": {
+      "name": "Run Config",
+      "description": "Generate or update run configurations interactively",
+      "prompt": "commands/run-config.md",
+      "tab": {
+        "ephemeral": {}
+      }
+    },
+    "custom_workflow": {
+      "name": "Custom Workflow",
+      "description": "Create a new custom workflow interactively",
+      "prompt": "commands/custom-workflow.md",
+      "tab": {
+        "ephemeral": {}
+      }
+    }
+  },
+  "queue": {
+    "worker": {
+      "entries": [
+        {
+          "status": "ready"
+        }
+      ]
+    },
+    "reviewer": {
+      "entries": [
+        {
+          "status": "in_review"
+        }
+      ]
+    },
+    "human-review": {
+      "entries": [
+        {
+          "status": "human_review"
+        }
+      ]
+    },
+    "in_progress": {
+      "entries": [
+        {
+          "status": "in_progress"
+        }
       ]
     }
-  }
+  },
+  "demo": true
 }

--- a/.claude/hooks/cate/needs-attention.mjs
+++ b/.claude/hooks/cate/needs-attention.mjs
@@ -1,0 +1,51 @@
+/**
+ * Claude Code Notification hook — sends a cate.v1.needsAttention event
+ * to the Leftenant MCP bridge when Claude needs user attention.
+ *
+ * Triggered by: permission_prompt, idle_prompt notifications
+ * Env vars required: TAB_ID, LEFTENANT_SOCKET
+ * Protocol: NDJSON over Unix socket (adapter-request)
+ */
+
+import { createConnection } from 'node:net';
+import { randomUUID } from 'node:crypto';
+
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => (input += chunk));
+process.stdin.on('end', () => {
+  const tabId = process.env.TAB_ID;
+  const socketPath = process.env.LEFTENANT_SOCKET;
+  if (!tabId || !socketPath) {
+    process.exit(0);
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(input);
+  } catch {
+    process.exit(0);
+  }
+
+  const conn = createConnection(socketPath, () => {
+    const request = JSON.stringify({
+      type: 'adapter-request',
+      id: randomUUID(),
+      method: 'tellCate',
+      params: {
+        tabId,
+        type: 'cate.v1.needsAttention',
+        body: {
+          notificationType: parsed.notification_type || '',
+          message: parsed.message || '',
+        },
+      },
+    });
+    conn.write(request + '\n');
+    conn.end();
+  });
+
+  conn.on('error', () => {
+    process.exit(0);
+  });
+});

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,5 +18,21 @@
     ],
     "defaultMode": "acceptEdits"
   },
-  "enabledMcpjsonServers": ["leftenant"]
+  "enabledMcpjsonServers": [
+    "leftenant"
+  ],
+  "hooks": {
+    "Notification": [
+      {
+        "matcher": "permission_prompt|structured_choice|idle_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/cate/needs-attention.mjs\"",
+            "async": true
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "leftenant": {
+      "command": "node",
+      "args": [
+        "${LEFTENANT_MCP_SERVER}"
+      ],
+      "env": {
+        "LEFTENANT_SOCKET": "${LEFTENANT_SOCKET}"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -315,7 +314,6 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.29.0"
       },
@@ -1427,7 +1425,6 @@
       "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.21.2.tgz",
       "integrity": "sha512-Bd6m6mrDrqpBEbX+g0rc66/ALd1sxlgdx5nfK9MAYO0yKLTOSK7McSYz1KcOYn3LQFCXOWfvXwaqih/b+REI1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "c12": "^3.3.3",
         "consola": "^3.4.2",
@@ -1494,24 +1491,6 @@
       },
       "peerDependencies": {
         "nuxt": "^3.21.2"
-      }
-    },
-    "node_modules/@nuxt/schema": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-4.4.2.tgz",
-      "integrity": "sha512-/q6C7Qhiricgi+PKR7ovBnJlKTL0memCbA1CzRT+itCW/oeYzUfeMdQ35mGntlBoyRPNrMXbzuSUhfDbSCU57w==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@vue/shared": "^3.5.30",
-        "defu": "^6.1.4",
-        "pathe": "^2.0.3",
-        "pkg-types": "^2.3.0",
-        "std-env": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.10.0"
       }
     },
     "node_modules/@nuxt/telemetry": {
@@ -4016,7 +3995,6 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.30.tgz",
       "integrity": "sha512-LqmFPDn89dtU9vI3wHJnwaV6GfTRD87AjWpTWpyrdVOObVtjIuSeZr181z5C4PmVx/V3j2p+0f7edFKGRMpQ5A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.29.0",
         "@vue/compiler-core": "3.5.30",
@@ -4176,7 +4154,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4505,7 +4482,6 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -4699,7 +4675,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4811,7 +4786,6 @@
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
       "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4904,7 +4878,6 @@
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
       "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "consola": "^3.2.3"
       }
@@ -4972,16 +4945,6 @@
       "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
       "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
       "license": "MIT"
-    },
-    "node_modules/commander": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/commondir": {
       "version": "1.0.1",
@@ -7553,7 +7516,6 @@
       "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.117.0.tgz",
       "integrity": "sha512-l3cbgK5wUvWDVNWM/JFU77qDdGZK1wudnLsFcrRyNo/bL1CyU8pC25vDhMHikVY29lbK2InTWsX42RxVSutUdQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/types": "^0.117.0"
       },
@@ -7738,7 +7700,6 @@
       "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.3.1.tgz",
       "integrity": "sha512-khUlZSwt9xXCaTbbxFYBKDc/bWAGWJjOgvxETwkTN7KRm66EeT1ZdZj6i2ceh9sP2Pzqsbc704r2yngBrxBVug==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^6.6.3",
         "vue-demi": "^0.14.10"
@@ -7786,7 +7747,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8481,7 +8441,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
       "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -9117,6 +9076,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/svgo/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/system-architecture": {
@@ -9913,7 +9881,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -10395,7 +10362,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.30.tgz",
       "integrity": "sha512-hTHLc6VNZyzzEH/l7PFGjpcTvUgiaPK5mdLkbjrTeWSRcEfxFrv56g/XckIYlE9ckuobsdwqd5mk2g1sBkMewg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.30",
         "@vue/compiler-sfc": "3.5.30",
@@ -10458,7 +10424,6 @@
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
       "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^6.6.4"
       },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -52,18 +52,14 @@ function handleRemove(_itemId: string): void {
                 <div class="cart-item-controls">
                   <div class="cart-item-quantity">
                     <label class="qty-label">Qty</label>
-                    <!--
-                      Quantity stepper — rendered but not wired to the store.
-                      TODO: Connect to cart.updateQuantity(item.id, newQty)
-                    -->
                     <InputNumber
                       :model-value="item.quantity"
                       :min="1"
                       :max="99"
-                      :disabled="true"
                       show-buttons
                       button-layout="horizontal"
                       :input-style="{ width: '3rem', textAlign: 'center' }"
+                      @update:model-value="(val) => cart.updateQuantity(item.id, val)"
                     />
                   </div>
 


### PR DESCRIPTION
## Summary
Enable the quantity stepper on cart items so users can change item quantities. The InputNumber component was rendered but disabled — this PR removes the `disabled` prop and wires the `@update:modelValue` event to the existing `cart.updateQuantity()` store action.

## Changes
- Remove `:disabled="true"` from the InputNumber component in `pages/index.vue`
- Add `@update:modelValue="(val) => cart.updateQuantity(item.id, val)"` handler
- Remove the TODO comment for quantity stepper wiring

## Test Plan
- [x] All 15 existing Vitest specs pass (including `updateQuantity` action tests)
- [x] Store already enforces min=1 via `Math.max(1, ...)` and InputNumber has `:min="1"` prop

Closes #3

---
Agent: learning-java-8675/worker-9b2142