### PR TITLE
ISSUE-5 feat(shipping): replace static shipping with dropdown selector

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -106,12 +106,14 @@ function handleRemove(_itemId: string): void {
                 </div>
 
                 <div class="shipping-selector">
-                  <!--
-                    Static shipping label — not connected to the store.
-                    TODO: Replace with Select component bound to cart.shippingOptions
-                    and @update:model-value="cart.setShippingOption($event)"
-                  -->
-                  <span class="shipping-static">Standard Shipping — $5.99</span>
+                  <Select
+                    :model-value="cart.selectedShippingOptionId"
+                    :options="cart.shippingOptions"
+                    option-label="label"
+                    option-value="id"
+                    @update:model-value="cart.setShippingOption($event)"
+                    class="shipping-select"
+                  />
                 </div>
               </div>
 
@@ -363,15 +365,11 @@ function handleRemove(_itemId: string): void {
 }
 
 .shipping-selector {
-  background: var(--p-surface-800, #27272a);
-  border: 1px solid var(--p-surface-700, #3f3f46);
-  border-radius: 8px;
-  padding: 0.625rem 0.875rem;
+  display: flex;
 }
 
-.shipping-static {
-  font-size: 0.875rem;
-  color: var(--p-surface-300, #d4d4d8);
+.shipping-select {
+  width: 100%;
 }
 
 .cart-summary-total {


### PR DESCRIPTION
## Summary
Replace the static "Standard Shipping — $5.99" text with a PrimeVue Select dropdown bound to the cart store's shipping options. Selecting a different option updates the shipping cost and cart total.

## Changes
- Replaced static shipping span with PrimeVue `Select` component in `pages/index.vue`
- Bound Select to `cart.shippingOptions` with `selectedShippingOptionId` as the model value
- Wired `@update:model-value` to `cart.setShippingOption()` to update shipping on selection change
- Updated CSS: replaced `.shipping-static` styles with `.shipping-select` for full-width Select

## Test Plan
- [x] All 15 existing Vitest specs pass (including shipping-related tests)
- [x] No store changes needed — all state, getters, and actions already existed

Closes #5

---
Agent: mattblueghostai/worker-482037